### PR TITLE
feat: add database port to admin-config

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -143,6 +143,12 @@
      
             </tr>
             <tr>
+                <td class="translate">sbfspot_DB_port</td>
+                <td>
+                    <input type="text" id="sbfspotPort" class="value" />
+                </td>
+            </tr>
+            <tr>
                 <td class="translate">sbfspot_DB_user</td>
                 <td>
                     <input type="text" id="sbfspotUser" class="value" />

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -145,6 +145,12 @@
         </div>
         <div class="row">
             <div class="col s6">
+                <input type="text" id="sbfspotPort" class="value" />
+                <label for="sbfspotPort" class="translate">sbfspot_DB_port</label>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col s6">
                 <input type="text" id="sbfspotUser" class="value" />
                 <label for="sbfspotUser" class="translate">sbfspot_DB_user</label>
             </div>

--- a/admin/words.js
+++ b/admin/words.js
@@ -98,6 +98,18 @@ systemDictionary = {
         "es": "base de datos mySQL IP",
         "pl": "IP bazy danych MySQL"
     },
+    "sbfspot_DB_port":
+    {
+        "en": "mySQL database port",
+        "de": "mySQL Datenbank-Port",
+        "ru": "Port-адрес mySQL",
+        "pt": "banco de dados MySQL",
+        "nl": "mySQL database port",
+        "fr": "base de données mySQL port",
+        "it": "port del database mySQL",
+        "es": "base de datos mySQL port",
+        "pl": "port bazy danych MySQL"
+    },
     "sbfspot_DB_databasename":
     {
         "en": "mySQL database name",

--- a/sbfspot.js
+++ b/sbfspot.js
@@ -386,6 +386,7 @@ function DB_Connect(cb) {
         mysql_connection = mysql.createConnection({
             host: adapter.config.sbfspotIP,
             user: adapter.config.sbfspotUser,
+            port: adapter.config.sbfspotPort,
             password: adapter.config.sbfspotPassword,
             database: adapter.config.sbfspotDatabasename
         });


### PR DESCRIPTION
In order to support MariaDB 10 it is essential to change the database port to 3307.
I added the port to the admin config, so it can be configured to what ever is needed.